### PR TITLE
feat: add element template

### DIFF
--- a/element-template/LICENSE.txt
+++ b/element-template/LICENSE.txt
@@ -1,0 +1,5 @@
+Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under one or more contributor license agreements and licensed to you under a proprietary license.
+You may not use this file except in compliance with the proprietary license.
+The proprietary license can be either the Camunda Self-Managed Free Edition license (available on Camunda’s website) or the Camunda Self-Managed Enterprise Edition license (a copy you obtain when you contact Camunda).
+The Camunda Self-Managed Free Edition comes for free but only allows for usage of the software (file) in non-production environments.
+If you want to use the software (file) in production, you need to purchase the Camunda Self-Managed Enterprise Edition.

--- a/element-template/README.md
+++ b/element-template/README.md
@@ -1,0 +1,5 @@
+# Camunda RPA Connector
+
+The **RPA Connector** allows you to execute Scripts in the Camunda RPA Worker.
+
+Learn more about the RPA Worker in the [Camunda Docs](https://docs.camunda.io/docs/next/components/RPA/getting-started/).

--- a/element-template/rpa-connector.json
+++ b/element-template/rpa-connector.json
@@ -1,0 +1,328 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "RPA Connector",
+  "description": "Connects with the Camunda RPA Worker",
+  "id": "camunda.connectors.rpa",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "engines": {
+    "camunda": "^8.7"
+  },
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "entriesVisible": false,
+  "groups": [
+    {
+      "id": "worker",
+      "label": "Worker"
+    },
+    {
+      "id": "script",
+      "label": "Script"
+    },
+    {
+      "id": "prerun",
+      "label": "Pre-run"
+    },
+    {
+      "id": "postrun",
+      "label": "Post-run"
+    },
+    {
+      "id": "input",
+      "label": "Input"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "property": "resourceType",
+        "linkName": "RPAScript"
+      },
+      "value": "RPA"
+    },
+    {
+      "group": "script",
+      "type": "String",
+      "feel": "optional",
+      "label": "Script ID",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "RPAScript",
+        "property": "resourceId"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "group": "script",
+      "type": "Dropdown",
+      "label": "Binding",
+      "id": "bindingType",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "RPAScript",
+        "property": "bindingType"
+      },
+      "choices": [
+        {
+          "name": "Latest",
+          "value": "latest"
+        },
+        {
+          "name": "Deployment",
+          "value": "deployment"
+        },
+        {
+          "name": "Version Tag",
+          "value": "versionTag"
+        }
+      ],
+      "value": "latest"
+    },
+    {
+      "group": "script",
+      "type": "String",
+      "label": "Version tag",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "RPAScript",
+        "property": "versionTag"
+      },
+      "condition": {
+        "property": "bindingType",
+        "equals": "versionTag"
+      }
+    },
+    {
+      "group": "worker",
+      "label": "Label",
+      "tooltip": "Define on which worker this task should be executed.",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "camundaRpaWorkerLabel"
+      },
+      "type": "String",
+      "value": "default",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "group": "worker",
+      "label": "Timeout",
+      "tooltip": "<div><p>A time duration defined as ISO 8601 durations format.</p><ul><li><code>PT15S</code> - 15 seconds</li><li><code>PT1H30M</code> - 1 hour and 30 minutes</li><li><code>P14D</code> - 14 days</li></ul></div>",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "camunda::timeout"
+      },
+      "type": "String",
+      "optional": true
+    },
+    {
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "value": "{\n  label: get or else(camundaRpaWorkerLabel, \"default\"),\n  baseName: \"camunda::RPA-Task::\",\n  definitionType: baseName + label\n}.definitionType"
+    },
+    {
+      "group": "prerun",
+      "label": "Enable pre-run script",
+      "tooltip": "Define an additional RPA script that should be executed before the main script is run.",
+      "type": "Boolean",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "camunda::enablePreRun"
+      },
+      "value": false,
+      "id": "enablePreRun"
+    },
+    {
+      "group": "prerun",
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "property": "resourceType",
+        "linkName": "Before"
+      },
+      "value": "RPA",
+      "condition": {
+        "property": "enablePreRun",
+        "equals": true
+      }
+    },
+    {
+      "group": "prerun",
+      "type": "String",
+      "feel": "optional",
+      "label": "Pre-run Script ID",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "Before",
+        "property": "resourceId"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "enablePreRun",
+        "equals": true
+      }
+    },
+    {
+      "group": "prerun",
+      "type": "Dropdown",
+      "label": "Pre-run Script Binding",
+      "id": "bindingTypePreRun",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "Before",
+        "property": "bindingType"
+      },
+      "condition": {
+        "property": "enablePreRun",
+        "equals": true
+      },
+      "choices": [
+        {
+          "name": "Latest",
+          "value": "latest"
+        },
+        {
+          "name": "Deployment",
+          "value": "deployment"
+        },
+        {
+          "name": "Version Tag",
+          "value": "versionTag"
+        }
+      ],
+      "value": "latest"
+    },
+    {
+      "group": "prerun",
+      "type": "String",
+      "label": "Pre-run Version tag",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "Before",
+        "property": "versionTag"
+      },
+      "condition": {
+        "property": "bindingTypePreRun",
+        "equals": "versionTag"
+      }
+    },
+        {
+      "group": "postrun",
+      "label": "Enable post-run script",
+      "tooltip": "Define an additional RPA script that should be executed after the main script is run.",
+      "type": "Boolean",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "camunda::postRun"
+      },
+      "value": false,
+      "id": "postRun"
+    },
+    {
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "property": "resourceType",
+        "linkName": "After"
+      },
+      "value": "RPA",
+      "condition": {
+        "property": "postRun",
+        "equals": true
+      }
+    },
+    {
+      "group": "postrun",
+      "type": "String",
+      "feel": "optional",
+      "label": "PostRun Script ID",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "After",
+        "property": "resourceId"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "postRun",
+        "equals": true
+      }
+    },
+    {
+      "group": "postrun",
+      "type": "Dropdown",
+      "label": "PostRun Script Binding",
+      "id": "bindingTypePostRun",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "After",
+        "property": "bindingType"
+      },
+      "condition": {
+        "property": "postRun",
+        "equals": true
+      },
+      "choices": [
+        {
+          "name": "Latest",
+          "value": "latest"
+        },
+        {
+          "name": "Deployment",
+          "value": "deployment"
+        },
+        {
+          "name": "Version Tag",
+          "value": "versionTag"
+        }
+      ],
+      "value": "latest"
+    },
+    {
+      "group": "postrun",
+      "type": "String",
+      "label": "Version tag",
+      "binding": {
+        "type": "zeebe:linkedResource",
+        "linkName": "After",
+        "property": "versionTag"
+      },
+      "condition": {
+        "property": "bindingTypePostRun",
+        "equals": "versionTag"
+      }
+    },
+    {
+      "group": "input",
+      "label": "Input mapping",
+      "type": "String",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "camundaRpaTaskInput"
+      },
+      "optional": true
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml;base64,PHN2ZyBpZD0iaWNvbiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHRpdGxlPmJvdDwvdGl0bGU+CiAgPHJlY3QgeD0iMTgiIHk9IjEwIiB3aWR0aD0iMiIgaGVpZ2h0PSIyIi8+CiAgPHJlY3QgeD0iMTIiIHk9IjEwIiB3aWR0aD0iMiIgaGVpZ2h0PSIyIi8+CiAgPHBhdGggZD0iTTI2LDIwSDIxVjE4aDFhMi4wMDIzLDIuMDAyMywwLDAsMCwyLTJWMTJoMlYxMEgyNFY4YTIuMDAyMywyLjAwMjMsMCwwLDAtMi0ySDIwVjJIMThWNkgxNFYySDEyVjZIMTBBMi4wMDIzLDIuMDAyMywwLDAsMCw4LDh2Mkg2djJIOHY0YTIuMDAyMywyLjAwMjMsMCwwLDAsMiwyaDF2Mkg2YTIuMDAyMywyLjAwMjMsMCwwLDAtMiwydjhINlYyMkgyNnY4aDJWMjJBMi4wMDIzLDIuMDAyMywwLDAsMCwyNiwyMFpNMTAsOEgyMnY4SDEwWm0zLDEwaDZ2MkgxM1oiLz4KICA8cmVjdCBpZD0iX1RyYW5zcGFyZW50X1JlY3RhbmdsZV8iIGRhdGEtbmFtZT0iJmx0O1RyYW5zcGFyZW50IFJlY3RhbmdsZSZndDsiIGNsYXNzPSJjbHMtMSIgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIi8+Cjwvc3ZnPgo="
+  }
+}


### PR DESCRIPTION
This PR is migrated from https://github.com/camunda/connectors/pull/3949

We want to keep Backend integration and Element template aligned, so keeping the code close is recommended. I added an additional Readme + License for the [Marketplace page](https://marketplace.cloud.camunda.io).

---

## Description

This connector allows you to execute a linked script on the RPA Worker

![image](https://github.com/user-attachments/assets/53b3e4be-b9b9-4f0e-89a7-09cfdf27a563)


## Related issues

related to https://github.com/camunda/product-hub/issues/2533

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

