### PR TITLE
fix(element-template): don't use camunda feel extensions

### DIFF
--- a/element-template/rpa-connector.json
+++ b/element-template/rpa-connector.json
@@ -133,7 +133,7 @@
       "binding": {
         "type": "zeebe:taskDefinition:type"
       },
-      "value": "={\n  label: get or else(camundaRpaWorkerLabel, \"default\"),\n  baseName: \"camunda::RPA-Task::\",\n  definitionType: baseName + label\n}.definitionType"
+      "value": "={\n  label: if (camundaRpaWorkerLabel = null or camundaRpaWorkerLabel = \"\") then \"default\" else camundaRpaWorkerLabel,\n  baseName: \"camunda::RPA-Task::\",\n  definitionType: baseName + label\n}.definitionType"
     },
     {
       "group": "prerun",


### PR DESCRIPTION
This PR removes `get or else` from the expressions, which are (incorrectly) marked as invalid FEEL syntax by the modeler:

![image](https://github.com/user-attachments/assets/1d321a94-bfd3-4631-83cb-9ddee7c83bf7)

closes #140 