### PR TITLE
Add helpful log message when Pip fails

### DIFF
--- a/rpa-worker-application/src/main/java/io/camunda/rpa/worker/python/PipFailureException.java
+++ b/rpa-worker-application/src/main/java/io/camunda/rpa/worker/python/PipFailureException.java
@@ -1,0 +1,6 @@
+package io.camunda.rpa.worker.python;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class PipFailureException extends RuntimeException { }


### PR DESCRIPTION
New message looks like this:
```json
{
  "timestamp": "2025-04-02T16:18:28.677592Z",
  "level": "ERROR",
  "message": "The Pip invocation has failed, and the Python requirements were not able to be installed into the environment.
Potential causes for a Pip failure include:
* Invalid extra-requirements being configured
* A dependency conflict between the core dependencies and dependencies specified in extra-requirements
* An unsupported Python version being used (< 3.8 or >= 3.13)
* Disk space or internet connectivity issues

For more information on working around unsupported Python versions please see
https://github.com/camunda/rpa-worker/discussions/170
",
  "logger": "io.camunda.rpa.worker.python.PythonSetupService",
  "thread": "pexec-1",
  "context": {
    "pythonVersion": "3.13.2",
    "pythonVersionSupported": "false"
  },
  "tags": []
}
```